### PR TITLE
Made changes to enable high power output

### DIFF
--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -6,6 +6,7 @@
 #include "board/adc.hpp"
 #include "lib/pid.hpp"
 #include "preset.hpp"
+#include "settings.hpp"  // needed to read high power setting
 
 /** Class for controlling heating and measuring cycle
 */
@@ -16,7 +17,7 @@ class Heating {
     static const int PID_K_PROPORTIONAL = 450;
     static const int PID_K_INTEGRAL = 1000;
     static const int PID_K_DERIVATE = 50;
-    static const int HEATING_POWER_MAX_MW = 40 * 1000;  // mW
+//    static const int HEATING_POWER_MAX_MW = 40 * 1000;  // mW
     static const int IDLE_MIN_TIME_MS = 3;  // ms
     static const int STABILIZE_TIME_MS = 2;  // ms
     static const int HEATING_MIN_POWER_MW = 100;  // mW
@@ -24,6 +25,9 @@ class Heating {
     static const int SUPPLY_VOLTAGE_HEATING_MIN_MV = 4300;  // mV
     static const int SUPPLY_VOLTAGE_MAX_MV = 18000;  // mV
     static const int TIP_RESISTANCE_SHORTED_MO = 500;  // mOhm
+    static const int RTM_TIP_RESISTANCE_MIN_MO = 1500  // mOhm
+    static const int RTM_TIP_RESISTANCE_MAX_MO = 2500  // mOhm
+    static const int RTU_TIP_RESISTANCE_MAX_MO = 4000  // mOhm
     static const int TIP_RESISTANCE_MIN_MO = 1500;  // mOhm
     static const int TIP_RESISTANCE_MAX_MO = 2500;  // mOhm
     static const int TIP_RESISTANCE_BROKEN_MO = 100000;  // mOhm
@@ -54,6 +58,13 @@ class Heating {
         BROKEN,
         SHORTED,
     } _tip_sensor_status = TipSensorStatus::UNKNOWN;
+ 
+ /* defines new class for tip type and sets default to UNKNOWN */
+    enum class TipType {
+        UNKNOWN,
+        RTM,
+        RTU,
+    } _tip_type = TipType::UNKNOWN
 
  private:
     Settings &_settings;
@@ -72,6 +83,7 @@ class Heating {
 
     int _requested_power_mw = 0;  // mW
     int _power_mw = 0;  // mW
+    int _max_power_mw = 40 * 1000  // mW (sets default max power output to 40W)
     int _cpu_voltage_mv_heat = 0;  // mV
     int _cpu_voltage_mv_idle = 0;  // mV
     int _supply_voltage_mv_heat = 0;  // mV
@@ -207,17 +219,28 @@ class Heating {
     void _check_heating_element() {
         if (_heater_resistance_mo < TIP_RESISTANCE_SHORTED_MO) {
             _heating_element_status = HeatingElementStatus::SHORTED;
-        } else if (_heater_resistance_mo < TIP_RESISTANCE_MIN_MO) {
+        } else if (_heater_resistance_mo < RTM_TIP_RESISTANCE_MIN_MO) {
             _heating_element_status = HeatingElementStatus::LOW_RESISTANCE;
         } else if (_heater_resistance_mo > TIP_RESISTANCE_BROKEN_MO) {
             _heating_element_status = HeatingElementStatus::BROKEN;
-        } else if (_heater_resistance_mo > TIP_RESISTANCE_MAX_MO) {
+        } else if (_heater_resistance_mo > RTU_TIP_RESISTANCE_MAX_MO) {
             _heating_element_status = HeatingElementStatus::HIGH_RESISTANCE;
         } else {
             _heating_element_status = HeatingElementStatus::OK;
         }
     }
-
+ 
+ /* Checks if resistance is in range of RTM or above it (RTU) or other (unknown) */
+    void _check_tip_type() {
+        if (_heater_resistance_mo > RTM_TIP_RESISTANCE_MAX_MO && _heater_resistance_mo < RTU_TIP_RESISTANCE_MAX_MO) {
+            _tip_type = TipType::RTU;
+        } else if (_heater_resistance_mo > RTM_TIP_RESISTANCE_MIN_MO && _heater_resistance_mo < RTM_TIP_RESISTACNCE_MAX_MO) {
+            _tip_type = TipType::RTM;
+        } else {
+            _tip_type = TipType::UNKNOWN;
+        }
+    }
+                  
     void _state_heating(const unsigned delta_ticks) {
         _measure_ticks += delta_ticks;
         if (board::Adc::get_instance().process() != board::Adc::State::DONE) return;
@@ -231,6 +254,7 @@ class Heating {
             _average_heating_measured_values();
             _calculate_total_energy();
             _calculate_tip_resistance();
+            _check_tip_type();  // establishes tip type once resistance is calculated
             _calculate_voltage_drop();
             _check_heating_element();
             _state = State::STABILIZE;
@@ -461,11 +485,29 @@ class Heating {
     TipSensorStatus getTipSensorStatus() const {
         return _tip_sensor_status;
     }
+ 
+    /** Getter tip type
+    indicate whether RTM or RTU tip is detected
+    
+    Return:
+        state from enum TipType
+    */
+    TipType getTipType() const {
+        return _tip_type;
+    }
 
     /** Initialize module
     */
     void init() {
-        _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, HEATING_POWER_MAX_MW);
+        _max_power_mw = (40 + (110 * _settings.get_high_power())) * 1000;  // mW
+     /* Below will use tip resistance to set max power, but need to figure out how to calculate tip resistance before init, or how to change max power after init   
+     if (_tip_type = TipType::RTM) {
+            _max_power_mw = 40 * 1000;  // mW
+        } else if (_tip_type = TipType::RTU) {
+            _max_power_mw = 150 * 1000; // mW
+        }
+        */
+        _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, _max_power_mw);
     }
 
     Preset &get_preset() {

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -155,7 +155,7 @@ class Main : public Screen {
         int len = power * 15 / 40000;  // default for 40W power limit
         
         /* account for 150W power limit of RTU tips */
-        if (_heating.getTipType() == Heating::TipType::TRU) {
+        if (_heating.getTipType() == Heating::TipType::RTU) {
             len = power * 15 / 150000;
         }
 

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -152,7 +152,12 @@ class Main : public Screen {
         if (_preset.is_standby()) return;
 
         int power = _heating.get_power_mw();
-        int len = power * 15 / 40000;
+        int len = power * 15 / 40000;  // default for 40W power limit
+        
+        /* account for 150W power limit of RTU tips */
+        if (_heating.getTipType() == Heating::TipType::TRU) {
+            len = power * 15 / 150000;
+        }
 
         if (len == 0 && power > 0) len = 1;
         if (len > 15) len = 15;

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -152,7 +152,12 @@ class Main : public Screen {
         if (_preset.is_standby()) return;
 
         int power = _heating.get_power_mw();
-        int len = power * 15 / 40000;
+        int len = power * 15 / 40000;  // default for 40W tips
+        
+        // account for 150W tips
+        if (_heating.getTipType() == Heating::TipType::RTU) {
+            len = power * 15 / 150000;
+        }
 
         if (len == 0 && power > 0) len = 1;
         if (len > 15) len = 15;

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -152,12 +152,7 @@ class Main : public Screen {
         if (_preset.is_standby()) return;
 
         int power = _heating.get_power_mw();
-        int len = power * 15 / 40000;  // default for 40W power limit
-        
-        /* account for 150W power limit of RTU tips */
-        if (_heating.getTipType() == Heating::TipType::TRU) {
-            len = power * 15 / 150000;
-        }
+        int len = power * 15 / 40000;
 
         if (len == 0 && power > 0) len = 1;
         if (len > 15) len = 15;

--- a/src/screen/menu.hpp
+++ b/src/screen/menu.hpp
@@ -39,6 +39,7 @@ class Menu : public Screen {
         ITEM_ADVANCED_MODE,
         ITEM_FAHRENHEIT,
         ITEM_LEFT_HANDED,
+        ITEM_HIGH_POWER,
         ITEM_TOTAL_ENERGY,
         ITEM_HEATER_POWER,
         ITEM_HEATER_CURRENT,
@@ -84,6 +85,13 @@ class Menu : public Screen {
         }, {
             "Left handed:",
             nullptr,
+            0,
+            0,
+            MenuItem::ItemType::VALUE_BINARY,
+            true,
+        }, {
+            "High power:";
+            mullptr,
             0,
             0,
             MenuItem::ItemType::VALUE_BINARY,

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -18,6 +18,7 @@ class Settings {
         PRESET_TEMPERATURE1,
         PRESET_TEMPERATURE2,
         STANDBY_TIMEOUT,
+        HIGH_POWER,
     };
 
     lib::Nv nv;
@@ -28,8 +29,9 @@ class Settings {
     bool _fahrenheit;
     bool _left_handed;
     bool _brightness;
+    bool _high_power;
 
-    static const size_t MIN_FREE = 7;
+    static const size_t MIN_FREE = 8;
 
 public:
 
@@ -41,6 +43,7 @@ public:
         _preset_temperatures[0] = nv.load_u16(PRESET_TEMPERATURE1, Default::PRESET_TEMPERATURE1);
         _preset_temperatures[1] = nv.load_u16(PRESET_TEMPERATURE2, Default::PRESET_TEMPERATURE2);
         _standby_timeout = nv.load_u16(STANDBY_TIMEOUT, Default::STANDBY_TIMEOUT);
+        _high_power = nv.load_bool(HIGH_POWER, false);
     }
 
     void save() {
@@ -51,6 +54,7 @@ public:
         nv.save_bool(BRIGHTNESS, _brightness);
         nv.save_u16(PRESET_TEMPERATURE1, _preset_temperatures[0]);
         nv.save_u16(PRESET_TEMPERATURE2, _preset_temperatures[1]);
+        nv.save_bool(HIGH_POWER, _high_power);
     }
 
 
@@ -90,6 +94,19 @@ public:
 
     void set_left_handed(const bool val=true) {
         _left_handed = val;
+    }
+    
+    
+    bool get_high_power() const {
+        return _high_power;
+    }
+    
+    void toggle_high_power() {
+        _high_power = != _high_power;
+    }
+    
+    void set_high_power() const {
+        _high_power = val;
     }
 
     static const uint8_t BRIGHTNESS_LOW = 40;


### PR DESCRIPTION
Made modifications to code to allow for selectable high power in settings menu.
Modified power output bar on display to account for power level.
Added tip type parameter and tip detection code. Need help adding code to automatically modify power output based on tip type. Tip Type can currently only be detected once iron starts running, but power output can only be modified on init, which requires power cycle, so tip type is lost. I could use tip type detection to change the power output setting above, but switching from RTU to RTM would require either a manual change or knowingly running the 40W tip with 150W power limit, which is probably not a good idea, even for a short time. So I need to make it run the tip momentarily on startup and THEN declare max power once tip resistance can be measured.