### PR TITLE
Enable High Power and Voltage Limit

### DIFF
--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -28,6 +28,7 @@ class Heating {
     static const int TIP_RESISTANCE_SHORTED_MO = 500;  // mOhm
     static const int RTM_TIP_RESISTANCE_MIN_MO = 1500;  // mOhm
     static const int RTM_TIP_RESISTANCE_MAX_MO = 2500;  // mOhm
+    static const int RTU_TIP_RESISTANCE_MIN_MO = 3000;  // mOhm
     static const int RTU_TIP_RESISTANCE_MAX_MO = 4000;  // mOhm
     static const int TIP_RESISTANCE_BROKEN_MO = 100000;  // mOhm
     static const int OVERHEAT_TEMPERATURE_MC_HW0X = 500 * 1000;  // 1/1000 degree Celsius
@@ -81,7 +82,6 @@ class Heating {
 
     int _requested_power_mw = 0;  // mW
     int _power_mw = 0;  // mW
-//    int _max_power_mw = 0;  // mW
     int _cpu_voltage_mv_heat = 0;  // mV
     int _cpu_voltage_mv_idle = 0;  // mV
     int _supply_voltage_mv_heat = 0;  // mV
@@ -220,6 +220,8 @@ class Heating {
             _heating_element_status = HeatingElementStatus::SHORTED;
         } else if (_heater_resistance_mo < RTM_TIP_RESISTANCE_MIN_MO) {
             _heating_element_status = HeatingElementStatus::LOW_RESISTANCE;
+        } else if (_heater_resistance_mo > RTM_TIP_RESISTANCE_MAX_MO && _heater_resistance_mo < RTU_TIP_RESISTANCE_MIN_MO) {
+            _heating_element_status = HeatingElementStatus::LOW_RESISTANCE;
         } else if (_heater_resistance_mo > TIP_RESISTANCE_BROKEN_MO) {
             _heating_element_status = HeatingElementStatus::BROKEN;
         } else if (_heater_resistance_mo > RTU_TIP_RESISTANCE_MAX_MO) {
@@ -230,7 +232,7 @@ class Heating {
     }
     
     void _check_tip_type() {
-        if (_heater_resistance_mo > RTM_TIP_RESISTANCE_MAX_MO && _heater_resistance_mo < RTU_TIP_RESISTANCE_MAX_MO) {
+        if (_heater_resistance_mo > RTU_TIP_RESISTANCE_MIN_MO && _heater_resistance_mo < RTU_TIP_RESISTANCE_MAX_MO) {
             _tip_type = TipType::RTU;
         } else if (_heater_resistance_mo > RTM_TIP_RESISTANCE_MIN_MO && _heater_resistance_mo < RTM_TIP_RESISTANCE_MAX_MO){
             _tip_type = TipType::RTM;
@@ -507,8 +509,6 @@ class Heating {
     /** Start heating cycle
     */
     void start() {
-//        _max_power_mw = (40 + (110 * _settings.get_high_power())) * 100;  //mW
-//        _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, _max_power_mw);
         if (_tip_type == TipType::RTU) {
             _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, RTU_HEATING_POWER_MAX_MW);
         } else {

--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -122,6 +122,7 @@ class Heating {
         _supply_voltage_mv_heat = 0;
         _heater_current_ma = 0;
         _power_mw = 0;
+        _tip_type = TipType::UNKNOWN;
         if (_requested_power_mw < HEATING_MIN_POWER_MW) {
             board::Adc::get_instance().measure_idle_start();
             _requested_power_mw = 0;

--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -510,16 +510,10 @@ class Heating {
 //        _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, _max_power_mw);
         if (_tip_type == TipType::RTU) {
             _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, RTU_HEATING_POWER_MAX_MW);
-            if (!_settings.get_high_power()) {
-                _settings.toggle_high_power();
-                _settings.save();
             }
         }
         else {
             _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, RTM_HEATING_POWER_MAX_MW);
-            if (_settings.get_high_power()) {
-                _settings.toggle_high_power();
-                _settings.save();
             }
         }
         if (_preset.is_standby() || getTipSensorStatus() != Heating::TipSensorStatus::OK) {

--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -510,11 +510,8 @@ class Heating {
 //        _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, _max_power_mw);
         if (_tip_type == TipType::RTU) {
             _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, RTU_HEATING_POWER_MAX_MW);
-            }
-        }
-        else {
+        } else {
             _pid.set_constants(PID_K_PROPORTIONAL, PID_K_INTEGRAL, PID_K_DERIVATE, PERIOD_TIME_MS, RTM_HEATING_POWER_MAX_MW);
-            }
         }
         if (_preset.is_standby() || getTipSensorStatus() != Heating::TipSensorStatus::OK) {
             _pid.reset();

--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -232,8 +232,7 @@ class Heating {
             _tip_type = TipType::RTU;
         } else if (_heater_resistance_mo > RTM_TIP_RESISTANCE_MIN_MO && _heater_resistance_mo < RTM_TIP_RESISTANCE_MAX_MO){
             _tip_type = TipType::RTM;
-        }
-        else {
+        } else {
             _tip_type = TipType::UNKNOWN;
         }
     }

--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -23,7 +23,8 @@ class Heating {
     static const int HEATING_MIN_POWER_MW = 100;  // mW
     static const int TIP_MAX_CURRENT_MA = 9000;  // mA
     static const int SUPPLY_VOLTAGE_HEATING_MIN_MV = 4300;  // mV
-    static const int SUPPLY_VOLTAGE_MAX_MV = 18000;  // mV
+    static const int RTM_SUPPLY_VOLTAGE_MAX_MV = 14000;  // mV
+    static const int RTU_SUPPLY_VOTLAGE_MAX_MV = 25000;  // mV
     static const int TIP_RESISTANCE_SHORTED_MO = 500;  // mOhm
     static const int RTM_TIP_RESISTANCE_MIN_MO = 1500;  // mOhm
     static const int RTM_TIP_RESISTANCE_MAX_MO = 2500;  // mOhm

--- a/src/heating.hpp
+++ b/src/heating.hpp
@@ -17,7 +17,7 @@ class Heating {
     static const int PID_K_INTEGRAL = 1000;
     static const int PID_K_DERIVATE = 50;
     static const int RTM_HEATING_POWER_MAX_MW = 40 * 1000;  // mW
-    static const int RTU_HEATING_POWER_MAX_MW = 150 * 100;  // mW
+    static const int RTU_HEATING_POWER_MAX_MW = 150 * 100;  // mW (I know this is only 15W, I am leaving it like this for safety until I confirm code works, then I will change it to 150W)
     static const int IDLE_MIN_TIME_MS = 3;  // ms
     static const int STABILIZE_TIME_MS = 2;  // ms
     static const int HEATING_MIN_POWER_MW = 100;  // mW

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -158,7 +158,7 @@ class Main : public Screen {
         if (_heating.getTipType() == Heating::TipType::RTU) {
             len = power * 15 / 150000;
         }
-        
+
         if (len == 0 && power > 0) len = 1;
         if (len > 15) len = 15;
 

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -186,6 +186,8 @@ class Main : public Screen {
                 _fb.draw_text(offset + 35, 0, "NO RT TIP", lib::Font::sans8);
             } else if (_heating.getTipSensorStatus() == Heating::TipSensorStatus::OVERHEAT) {
                 _fb.draw_text(offset + 35, 0, "OVERHEAT!", lib::Font::sans8);
+            } else if ((_heating.getTipType() == Heating::TipType::RTM && _heating.get_supply_voltage_mv_idle() > _heating.RTM_SUPPLY_VOLTAGE_MAX_MV) || (_heating.getTipType() == Heating::TipType::RTU && _heating.get_supply_voltage_mv_idle() > _heating.RTU_SUPPLY_VOLTAGE_MAX_MV)) {
+                _fb.draw_text(offset + 35, 0, "VOLTAGE TOO HIGH!", lib::Font::sans8);
             }
         } else if (_heating.get_steady_ms() > IDLE_MESSAGE_MS && status_blink < 4) {
             _fb.draw_text(offset + 35, 0, "IDLE", lib::Font::sans8);

--- a/src/screen/main.hpp
+++ b/src/screen/main.hpp
@@ -152,8 +152,13 @@ class Main : public Screen {
         if (_preset.is_standby()) return;
 
         int power = _heating.get_power_mw();
-        int len = power * 15 / 40000;
-
+        int len = power * 15 / 40000;  // default for 40W tips
+        
+        // account for 150W tips
+        if (_heating.getTipType() == Heating::TipType::RTU) {
+            len = power * 15 / 150000;
+        }
+        
         if (len == 0 && power > 0) len = 1;
         if (len > 15) len = 15;
 


### PR DESCRIPTION
This enables high power via auto detection of tip resistance (1.5-2.5ohm for RTM, 3-4ohm for RTU, otherwise UNKNOWN).

It dynamically adjusts output power as it runs based on the determined tip resistance. For RTM tips, it allows a max of 40W. For RTU tips, it currently only allows a max of 15W, until testing can validate that the code works properly, and then max power will be increased to the full 150W.

It limits power to 150mW in case the tip is UNKNOWN in order to prevent damage. This is set every time the _start() cycle runs so that switching from RTU to RTM does not cause damage.

It adjusts the scale of the power display bar for 40W or 150W output.

It also forces a stop and displays an error on the display if voltage is more than 14V when an RTM tip is plugged in, or 25V when an RTU tip is plugged in.

Sorry I'm creating a new pull request, I couldn't figure out how to change the code when I found errors before, so I started over.